### PR TITLE
Control block render methods

### DIFF
--- a/src/solenoid/components.clj
+++ b/src/solenoid/components.clj
@@ -72,7 +72,10 @@
 (defmethod render-controller Slider   [m] (base-component m {} {:style {:display "inline-block"}}))
 (defmethod render-controller EdnBlock [m] (let [val (str (:value m))] (base-component (assoc m :value val))))
 
-(defn render-control-block-result
+(defmulti render-control-block-result (fn [control-block _] (-> control-block :state deref meta :result-type)))
+(defmulti render-control-block (fn [control-block] (-> control-block :state deref meta :control-block-type)))
+
+(defmethod render-control-block-result :default
   [{:keys [id state]} oob?]
   (let [result @state]
     [:div.text-center
@@ -82,8 +85,9 @@
        (when oob? {:hx-swap-oob "innerHTML"}))
      (or result "no result")]))
 
-(defn render-control-block
-  [{:keys [id control-ids] :as control-block}]
+(defn render-control-block*
+  "Base implementation for control block render methods, useful for creating custom `render-control-block` methods."
+  [{:keys [id control-ids]} rendered-result]
   (let [controls (map @c/registry control-ids)]
     [:div.col.g-4
      [:div.card {:id id}
@@ -95,21 +99,17 @@
           :hx-swap "none"}]]]
       [:div.card-body
        (into [:div.row.controls] (mapv render-controller controls))
-       [:div.row.my-3 (render-control-block-result control-block false)]
+       [:div.row.my-3 rendered-result]
        [:div.row
         [:div.col [:button.btn.btn-outline-secondary.btn-sm
                    {:hx-post (str "/action/def/" id)
                     :hx-swap "none"} "def"]]]]]]))
 
-
-
-
-
-
-
-
-
-
+(defmethod render-control-block :default
+  [control-block]
+  (render-control-block*
+    control-block
+    (render-control-block-result control-block false)))
 
 #_(defn toggle
   [{:keys [id value] :as val-map}]

--- a/src/solenoid/components.clj
+++ b/src/solenoid/components.clj
@@ -24,16 +24,17 @@
   (-> (str "js:" (json/generate-string (assoc m :value "____")))
       (str/replace #"\"____\"" get-value-js-str)))
 
+;; PROBLEM: make a mechanism that easily swaps :input :textearea, etc. to make the base-component more re-usable
 (def control-type->input-type
   {:slider "range"
    :num    "number"
    :text   "text"
-   :edn    "text"})
+   :edn    "textarea"})
 
 (defn- make-input-map
   [{:keys [id value control-type]}]
   {:id         id
-   :class      ["form-control-sm" (name control-type)]
+   :class      ["form-control-sm" (name control-type) "col"]
    :type       (control-type->input-type control-type)
    :value      (str value)
    :hx-get     (str "/controller/" id)
@@ -41,18 +42,16 @@
    :hx-target  (str "#" (name id) "-value")})
 
 (defn base-component
-  ([control]
-   (base-component
-     control {} {}))
-
-  ([{:keys [id display-name value min max control-type] :as control} input-map-overrides value-container-map-overrides]
+  ([control] (base-component control {} {}))
+  ([{:keys [id display-name value min max control-type] :as control}
+    input-map-overrides value-container-map-overrides]
    (let [get-value-js-str (str "document.getElementById('" (name id) "').value")]
      [:div.control.row.my-1.mx-0.p-0
       [:span.col-3.text-end.mb-0.mt-2 (str (or display-name id))]
       [:span.col-7 {:class (str (name control-type) "-container")}
        [:div.row.small
         (when min [:span.col-2.text-end.mb-0.mt-1 min])
-        [:input.col.col
+        [:input
          (merge
            (make-input-map control)
            {:hx-vals (make-hx-vals control get-value-js-str)}

--- a/src/solenoid/server.clj
+++ b/src/solenoid/server.clj
@@ -1,7 +1,7 @@
 (ns solenoid.server
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [hiccup.core :as h]
+            [hiccup2.core :as hiccup]
             [org.httpkit.server :as srv]
             [ring-sse-middleware.core :as sse-r]
             [ring-sse-middleware.wrapper :as sse-w]
@@ -11,135 +11,137 @@
             [solenoid.components :as components]
             [solenoid.utils :as u]))
 
-(defn app-body
+(defn- app-body
   []
   [:section#app
    [:main
     [:div.container
      (into
        [:div.row.row-cols-1.row-cols-sm-1.row-cols-md-2.row-cols-lg-3.row-cols-xl-4.g-2]
-       ;; PROBLEM: clean up this rendering a bit.
        (concat
+         ;; render any controllers not associated with control blocks (can do this by using c/cursor directly)
          (mapv components/render-controller
                (remove #(or (contains? % :block-id)
                             (str/includes? (name (:id %)) "controlblock"))
                        (vals @c/registry)))
+         ;; render the control blocks in the registry
          (mapv components/render-control-block
-               (filter #(str/includes? (name (:id %)) "controlblock") (vals @c/registry)))))]]])
+               (filter #(str/includes? (name (:id %)) "controlblock")
+                       (vals @c/registry)))))]]])
 
-(defn template
-  [& {:keys [head-entries]}]
-  (list
-    "<!DOCTYPE html>"
-    (h/html
-      (into [:head]
-            (concat
-              [[:meta {:charset "UTF-8"}]
-               [:meta {:name    "viewport"
-                       :content "width=device-width, initial-scale=1"}]
-               [:title "solenoid"]
-               [:style (slurp (io/resource "bootstrap.min.css"))]
-               [:script (slurp (io/resource "bootstrap.bundle.min.js"))]
-               [:style (slurp (io/resource "style.css"))]
-               [:script (slurp (io/resource "htmx.min.js"))]
-               [:script (slurp (io/resource "sse.js"))]]
-              head-entries))
-      [:body.d-flex.flex-column.h-100
-       {:data-bs-theme "dark"}
-       [:span {:class       "container-fluid"
-               :hx-ext      "sse"
-               :sse-connect "/events"}
-        [:div#reloader.row
-         {:hx-trigger "sse:reload"
-          :hx-get     "/reload"
-          :hx-target  "#reloader"}
-         (app-body)]]
-       [:footer.footer.mt-auto.py-3
-        [:h3.mt-4.text-center "solenoid"]
-        [:div.container
-         [:p "Created by "
-          [:a {:href "https://twitter.com/RustyVermeer"} "adam-james"]]]]])))
+(defn- template
+  ([] (template nil))
+  ([{:keys [head-entries]}]
+   (list
+     "<!DOCTYPE html>"
+     (hiccup/html
+       (into [:head]
+             (concat
+               [[:meta {:charset "UTF-8"}]
+                [:meta {:name    "viewport"
+                        :content "width=device-width, initial-scale=1"}]
+                [:title "solenoid"]
+                [:style (slurp (io/resource "bootstrap.min.css"))]
+                [:script (slurp (io/resource "bootstrap.bundle.min.js"))]
+                [:style (slurp (io/resource "style.css"))]
+                [:script (slurp (io/resource "htmx.min.js"))]
+                [:script (slurp (io/resource "sse.js"))]]
+               head-entries))
+       [:body.d-flex.flex-column.h-100
+        {:data-bs-theme "dark"}
+        [:span {:class       "container-fluid"
+                :hx-ext      "sse"
+                :sse-connect "/events"}
+         [:div#reloader.row
+          {:hx-trigger "sse:reload"
+           :hx-get     "/reload"
+           :hx-target  "#reloader"}
+          (app-body)]]
+        [:footer.footer.mt-auto.py-3
+         [:h3.mt-4.text-center "solenoid"]
+         [:div.container
+          [:p "Created by "
+           [:a {:href "https://twitter.com/RustyVermeer"} "adam-james"]]]]]))))
 
-;; PROBLEM: maybe this should use :keyword optional args?
-;; PROBLEM: & opts flow through fns should be cleaner than it is, I think
 ;; PROBLEM: Clean up the routes by pulling fns out and using defn -> good for documentation/readability
-(defn routes
-  [& opts]
-  [{:path     "/"
-    :method   :get
-    :response (fn [_]
-                {:status 200
-                 :body   (h/html (template (first opts)))})}
-   {:path     "/action/:action/:id"
-    :method   :post
-    :response
-    ;; PROBLEM: This could be reworked with defmethod to allow users to define custom actions
-    (fn [{:keys [params]}]
-      (let [{:keys [id action]} params
-            id                  (u/stringified-key->keyword id)
-            action              (u/stringified-key->keyword action)
-            control-ids         (get-in @c/registry [id :control-ids])]
-        (case action
-          :delete
-          ;; dissoc all of the controls and the control-block in one go, causing only one :reload
-          (swap! c/registry (fn [m] (apply (partial dissoc m) (conj control-ids id))))
+(defn- routes
+  ([] (routes nil))
+  ([opts]
+   [{:path     "/"
+     :method   :get
+     :response (fn [_]
+                 {:status 200
+                  :body   (hiccup/html (template opts))})}
+    {:path     "/action/:action/:id"
+     :method   :post
+     :response
+     ;; PROBLEM: This could be reworked with defmethod to allow users to define custom actions
+     (fn [{:keys [params]}]
+       (let [{:keys [id action]} params
+             id                  (u/stringified-key->keyword id)
+             action              (u/stringified-key->keyword action)
+             control-ids         (get-in @c/registry [id :control-ids])]
+         (case action
+           :delete
+           ;; dissoc all of the controls and the control-block in one go, causing only one :reload
+           (swap! c/registry (fn [m] (apply (partial dissoc m) (conj control-ids id))))
 
-          :def
-          (let [state (get-in @c/registry [id :state])
-                value (if state
-                        @state
-                        (get-in @c/registry [id :value]))]
-            (intern 'user (symbol (name id)) value))
+           :def
+           (let [state (get-in @c/registry [id :state])
+                 value (if state
+                         @state
+                         (get-in @c/registry [id :value]))]
+             (intern 'user (symbol (name id)) value))
 
-          ;; no action
-          (println "no action"))
-        {:status 200
-         :body   nil}))}
-   ;; hit when a control is altered in the UI. ID and value must always be available
-   {:path     "/controller/:id"
-    :method   :get
-    :response (fn [{:keys [params query-string]}]
-                (let [{:keys [id]}                          params
-                      id                                    (u/stringified-key->keyword id)
-                      {:keys [value block-id control-type]} (u/query-string->map query-string)
-                      value                                 (if (= :text (keyword control-type))
-                                                              (u/get-string-value query-string)
-                                                              value)
-                      block-id                              (when block-id (u/stringified-key->keyword block-id))]
-                  (when value (swap! c/registry assoc-in [id :value] value))
-                  {:status 200
-                   :body   (str (h/html (if (= (keyword control-type) :edn) (str value) value))
-                                (when block-id
-                                  (h/html (components/render-control-block-result
-                                            (get @c/registry block-id)
-                                            true))))}))}
-   ;; gets hit when you (reset! event :reload) on the backend
-   {:path     "/reload"
-    :method   :get
-    :response (fn [_req]
-                {:status 200
-                 :body   (h/html (app-body))})}])
+           ;; no action
+           (println "no action"))
+         {:status 200
+          :body   nil}))}
+    ;; hit when a control is altered in the UI. ID and value must always be available
+    {:path     "/controller/:id"
+     :method   :get
+     :response (fn [{:keys [params query-string]}]
+                 (let [{:keys [id]}                          params
+                       id                                    (u/stringified-key->keyword id)
+                       {:keys [value block-id control-type]} (u/query-string->map query-string)
+                       value                                 (if (= :text (keyword control-type))
+                                                               (u/get-string-value query-string)
+                                                               value)
+                       block-id                              (when block-id (u/stringified-key->keyword block-id))]
+                   (when value (swap! c/registry assoc-in [id :value] value))
+                   {:status 200
+                    :body   (str (hiccup/html (if (= (keyword control-type) :edn) (str value) value))
+                                 (when block-id
+                                   (hiccup/html (components/render-control-block-result
+                                                  (get @c/registry block-id)
+                                                  true))))}))}
+    ;; gets hit when you (reset! event :reload) on the backend
+    {:path     "/reload"
+     :method   :get
+     :response (fn [_req]
+                 {:status 200
+                  :body   (hiccup/html (app-body))})}]))
 
 ;; PROBLEM: this works perfectly EXCEPT it will only refresh the browser if its the last focused window?
 ;; PROBLEM: should use 'idiomorph' for merge swapping, which should help preserve focus and state better
-(defn app
-  [& opts]
-  (-> #(ruuter/route (routes (first opts)) %)
-      (sse-r/streaming-middleware
-        sse-h/generate-stream
-        {:request-matcher (fn [req] ((partial sse-r/uri-match "/events") req))
-         :chunk-generator (-> (fn [_]
-                                (let [evt @c/event]
-                                  (if (= evt :reload)
-                                    (do (reset! c/event :waiting)
-                                        "event: reload\ndata:\"\"")
-                                    "waiting...")))
-                              (sse-w/wrap-delay 100)
-                              sse-w/wrap-sse-event
-                              sse-w/wrap-pst)})))
+(defn- app
+  ([] (app nil))
+  ([opts]
+   (-> #(ruuter/route (routes opts) %)
+       (sse-r/streaming-middleware
+         sse-h/generate-stream
+         {:request-matcher (fn [req] ((partial sse-r/uri-match "/events") req))
+          :chunk-generator (-> (fn [_]
+                                 (let [evt @c/event]
+                                   (if (= evt :reload)
+                                     (do (reset! c/event :waiting)
+                                         "event: reload\ndata:\"\"")
+                                     "waiting...")))
+                               (sse-w/wrap-delay 100)
+                               sse-w/wrap-sse-event
+                               sse-w/wrap-pst)}))))
 
-(defonce server (atom nil))
-(def port 9876)
+(defonce ^:private server (atom nil))
 
 (defn stop-server []
   (when-not (nil? @server)

--- a/src/solenoid/server.clj
+++ b/src/solenoid/server.clj
@@ -11,6 +11,10 @@
             [solenoid.components :as components]
             [solenoid.utils :as u]))
 
+(defmacro ^:private html
+  [options & content]
+  `(str (hiccup/html {:escape-strings? false} ~options ~@content)))
+
 (defn- app-body
   []
   [:section#app
@@ -34,7 +38,7 @@
   ([{:keys [head-entries]}]
    (list
      "<!DOCTYPE html>"
-     (hiccup/html
+     (html
        (into [:head]
              (concat
                [[:meta {:charset "UTF-8"}]
@@ -71,9 +75,9 @@
      :method   :get
      :response (fn [_]
                  {:status 200
-                  :body   (hiccup/html (template opts))})}
-    {:path     "/action/:action/:id"
-     :method   :post
+                  :body   (html (template opts))})}
+    {:path   "/action/:action/:id"
+     :method :post
      :response
      ;; PROBLEM: This could be reworked with defmethod to allow users to define custom actions
      (fn [{:keys [params]}]
@@ -110,17 +114,17 @@
                        block-id                              (when block-id (u/stringified-key->keyword block-id))]
                    (when value (swap! c/registry assoc-in [id :value] value))
                    {:status 200
-                    :body   (str (hiccup/html (if (= (keyword control-type) :edn) (str value) value))
+                    :body   (str (html (if (= (keyword control-type) :edn) (str value) value))
                                  (when block-id
-                                   (hiccup/html (components/render-control-block-result
-                                                  (get @c/registry block-id)
-                                                  true))))}))}
+                                   (html (components/render-control-block-result
+                                           (get @c/registry block-id)
+                                           true))))}))}
     ;; gets hit when you (reset! event :reload) on the backend
     {:path     "/reload"
      :method   :get
      :response (fn [_req]
                  {:status 200
-                  :body   (hiccup/html (app-body))})}]))
+                  :body   (html (app-body))})}]))
 
 ;; PROBLEM: this works perfectly EXCEPT it will only refresh the browser if its the last focused window?
 ;; PROBLEM: should use 'idiomorph' for merge swapping, which should help preserve focus and state better

--- a/src/solenoid/utils.clj
+++ b/src/solenoid/utils.clj
@@ -1,6 +1,5 @@
 (ns solenoid.utils
-  (:require [clojure.string :as str]
-            [cheshire.core :as json])
+  (:require [clojure.string :as str])
   (:import [java.net URLDecoder]))
 
 (defn parse-body [body]
@@ -10,30 +9,9 @@
       second
       URLDecoder/decode))
 
-(defn parse-query-string [query-string]
-  (when query-string
-    (-> query-string
-        (str/split #"=")
-        second)))
-
 (defn url-encoded-str->str
   [s]
   (URLDecoder/decode s))
-
-(defn maybe-parse-number
-  [s]
-  (if (string? s)
-    (or (parse-long s)
-        (parse-double s)
-        s)
-    s))
-
-(defn maybe-parse-boolean
-  [s]
-  (case s
-    "true" true
-    "false" false
-    s))
 
 (defn maybe-read-string
   [s]


### PR DESCRIPTION
This PR adds the ability to define custom methods for both `render-control-block` and `render-control-block-result`, the latter of which I think will be used more often.