### PR TITLE
Derefs inside letcontrols body can drive updates. Hacky though.

### DIFF
--- a/src/solenoid/components.clj
+++ b/src/solenoid/components.clj
@@ -20,16 +20,24 @@
 
 
 (defn- make-hx-vals
-  [m get-value-js-str]
+  [m get-value-fn]
   (-> (str "js:" (json/generate-string (assoc m :value "____")))
-      (str/replace #"\"____\"" get-value-js-str)))
+      (str/replace #"\"____\"" (get-value-fn m))))
 
 ;; PROBLEM: make a mechanism that easily swaps :input :textearea, etc. to make the base-component more re-usable
 (def control-type->input-type
   {:slider "range"
    :num    "number"
    :text   "text"
-   :edn    "textarea"})
+   :toggle "checkbox"})
+
+(def control-type->form-key
+  {:slider :input
+   :num    :input
+   :text   :input
+   :toggle :input
+   :edn    :textarea
+   :point  :div})
 
 (defn- make-input-map
   [{:keys [id value control-type]}]

--- a/src/solenoid/controls.clj
+++ b/src/solenoid/controls.clj
@@ -167,12 +167,13 @@
   [form]
   (->> form
        (tree-seq seqable? identity)
-       (filter seqable?)
+       (filter #(and (not (map? %)) (seqable? %)))
        (map (fn [[sym r]]
               (when (or (= 'deref sym)
                         (= 'clojure.core/deref sym))
                 r)))
        (remove nil?)
+       distinct
        vec))
 
 ;; PROBLEM: remove the 'eval' in there??

--- a/src/solenoid/macros.clj
+++ b/src/solenoid/macros.clj
@@ -12,7 +12,13 @@
        val#)))
 
 (defmacro formula
-  "Creates an atom that updates when its binding references update."
+  "Creates an atom that updates when its binding references update.
+  Optionally, the last binding can be a keyword `:dependents` with a keyword value.
+  This dependents keyword is used to construct the add-watch key which will have the form:
+  `[:update-formula-11111 :controlblock-11111]`.
+
+  This is done so that you can find all controlblocks that are dependent on this formula
+  by using `solenoid.utils/get-watches` and looking at the last element in each result."
   [bindings & formula]
   (let [l2 (take-last 2 bindings)
         dependents (when (= (first l2) :dependents) (second l2))
@@ -28,5 +34,5 @@
          (doseq [r# ~(vec (take-nth 2 bindings))]
            ;; adds a watch to each atom in the binding that is responsible for
            ;; updating this formula whenever that atom changes.
-           (add-watch r# ~(vec (remove nil? [(keyword (str "update-formula-" (gensym))) dependents])) update-fn#))
+           (add-watch r# ~(vec (remove nil? [(keyword (gensym "update-formula-")) dependents])) update-fn#))
          formula#))))

--- a/src/solenoid/server.clj
+++ b/src/solenoid/server.clj
@@ -1,7 +1,7 @@
 (ns solenoid.server
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [hiccup2.core :as hiccup]
+            [hiccup.core :as hiccup :refer [html]]
             [org.httpkit.server :as srv]
             [ring-sse-middleware.core :as sse-r]
             [ring-sse-middleware.wrapper :as sse-w]
@@ -11,7 +11,7 @@
             [solenoid.components :as components]
             [solenoid.utils :as u]))
 
-(defmacro ^:private html
+#_(defmacro ^:private html
   [options & content]
   `(str (hiccup/html {:escape-strings? false} ~options ~@content)))
 

--- a/src/solenoid/server.clj
+++ b/src/solenoid/server.clj
@@ -21,7 +21,7 @@
    [:main
     [:div.container
      (into
-       [:div.row.row-cols-1.row-cols-sm-1.row-cols-md-2.row-cols-lg-3.row-cols-xl-4.g-2]
+       [:div.row.row-cols-1.row-cols-sm-1.row-cols-md-2.row-cols-lg-3.g-2]
        (concat
          ;; render any controllers not associated with control blocks (can do this by using c/cursor directly)
          (mapv components/render-controller

--- a/src/solenoid/utils.clj
+++ b/src/solenoid/utils.clj
@@ -31,10 +31,13 @@
     (let [m (->> (str/split query-string #"[=&]")
                  (partition 2)
                  (mapv vec)
-                 (into {}))]
+                 (group-by first))]
       (-> m
-          (update-vals url-encoded-str->str)
-          (update-vals maybe-read-string)
+          (update-vals #(map second %))
+          (update-vals #(map url-encoded-str->str %))
+          (update-vals #(map maybe-read-string %))
+          (update-vals #(vec (replace {'NaN nil} %)))
+          (update-vals #(if (= (count %) 1) (first %) %))
           (update-keys keyword)))
     {}))
 


### PR DESCRIPTION
This is one approach to allow derefs inside a letcontrols body drive updates of that control's results. This means you can def a letcontrol and use its value in other letcontrols and see the updates propagate appropriately.

I wanted to attach metadata to do this, but atoms don't allow metadata (at least not by default) because they are not objects.

Instead, I altered my macros to add-watches with keywords of shape `[:update-formula :controlblock-that-depends-on-this-atom]`.

Using `solenoid.utils/get-watches`, you can then find ALL of the control blocks that depend on whatever atom you're updating, and then update _them_ appropriately.

So, this is a slight abuse of the add-watch keywords, but it gets the job done!