### PR TITLE
Add a letview macro

### DIFF
--- a/src/solenoid/controls.clj
+++ b/src/solenoid/controls.clj
@@ -250,3 +250,29 @@
                                                         ~@body))]
                                state#)}))
            :state))))
+
+(defmacro letview
+  [& body]
+  (let [block-id#        (keyword (gensym "controlblock-"))
+        ;; Get any derefs that are within the body of the letcontrols
+        derefs-in-body#  (get-derefs body)
+        ;; Add these derefs so that watches are properly registsered to all refs that drive this block.
+        cursor-bindings# (vec (concat ['_ nil] (interleave derefs-in-body# derefs-in-body#)))
+        ;; `make-deref-bindings` builds up the let binding vector
+        ;; for the regular let that sits inside the formula macro.
+        ;; That let form is needed for re-binding the user's symbols to the cursors for each control.
+        ;; we remove the derefs-in-body because those will have been de-referenced in the body already.
+        deref-bindings#  ['_ nil]
+        ;; cursor-bindings will add the optional :dependents key with this block's ID
+        ;; so that watches can be added properly to all refs used in the body. See `solenoid.macros/formula`.
+        cursor-bindings# (vec (concat
+                                cursor-bindings#
+                                (when (seq derefs-in-body#) [:dependents block-id#])))]
+    `(-> (register!
+           (map->ControlBlock
+             {:id          ~block-id#
+              :state       (let [state# (sm/formula ~cursor-bindings#
+                                                    (let ~deref-bindings#
+                                                      ~@body))]
+                             state#)}))
+         :state)))

--- a/src/solenoid/controls.clj
+++ b/src/solenoid/controls.clj
@@ -228,7 +228,7 @@
         ;; Add these derefs so that watches are properly registsered to all refs that drive this block.
         cursor-bindings# (vec (concat
                                 (make-cursor-bindings (interleave syms controls))
-                                (interleave derefs-in-body# derefs-in-body#)))
+                                (interleave (map #(-> % name symbol) derefs-in-body#) derefs-in-body#)))
         ;; `make-deref-bindings` builds up the let binding vector
         ;; for the regular let that sits inside the formula macro.
         ;; That let form is needed for re-binding the user's symbols to the cursors for each control.
@@ -257,7 +257,7 @@
         ;; Get any derefs that are within the body of the letcontrols
         derefs-in-body#  (get-derefs body)
         ;; Add these derefs so that watches are properly registsered to all refs that drive this block.
-        cursor-bindings# (vec (concat ['_ nil] (interleave derefs-in-body# derefs-in-body#)))
+        cursor-bindings# (vec (concat ['_ nil] (interleave (map #(-> % name symbol) derefs-in-body#) derefs-in-body#)))
         ;; `make-deref-bindings` builds up the let binding vector
         ;; for the regular let that sits inside the formula macro.
         ;; That let form is needed for re-binding the user's symbols to the cursors for each control.

--- a/src/solenoid/controls.clj
+++ b/src/solenoid/controls.clj
@@ -253,7 +253,7 @@
 
 (defmacro letview
   [& body]
-  (let [block-id#        (keyword (gensym "controlblock-"))
+  (let [block-id#        (keyword (gensym "viewblock-"))
         ;; Get any derefs that are within the body of the letcontrols
         derefs-in-body#  (get-derefs body)
         ;; Add these derefs so that watches are properly registsered to all refs that drive this block.

--- a/src/solenoid/macros.clj
+++ b/src/solenoid/macros.clj
@@ -34,5 +34,6 @@
          (doseq [r# ~(vec (take-nth 2 bindings))]
            ;; adds a watch to each atom in the binding that is responsible for
            ;; updating this formula whenever that atom changes.
-           (add-watch r# ~(vec (remove nil? [(keyword (gensym "update-formula-")) dependents])) update-fn#))
+           (when r#
+             (add-watch r# ~(vec (remove nil? [(keyword (gensym "update-formula-")) dependents])) update-fn#)))
          formula#))))

--- a/src/solenoid/server.clj
+++ b/src/solenoid/server.clj
@@ -22,14 +22,18 @@
        (concat
          ;; render any controllers not associated with control blocks (can do this by using c/cursor directly)
          (mapv components/render-controller
-               (remove #(or (contains? % :block-id)
-                            (str/includes? (name (:id %)) "controlblock"))
+               (remove #(or (not (map? % ))
+                            (contains? % :block-id)
+                            (str/includes? (name (:id %)) "controlblock")
+                            (str/includes? (name (:id %)) "viewblock"))
                        (vals @c/registry)))
          ;; render the control blocks in the registry
          (->> @c/registry
               vals
-              (filter #(str/includes? (name (:id %)) "controlblock"))
-              (sort-by :id)
+              (filter #(and (map? %)
+                            (or (str/includes? (name (:id %)) "controlblock")
+                                (str/includes? (name (:id %)) "viewblock"))))
+              (sort-by #(-> % :id str (str/split #"-") second parse-long))
               (mapv components/render-control-block))))]]])
 
 (defn- template


### PR DESCRIPTION
This is a useful macro I've thought of in passing and realized it would be fairly simple to add, and quite useful! 

It lets you add control blocks without needing to bind controls. The rendered content can still use derefs inside the body, so you still get reactivity.

This can pair nicely with the pattern of making a control block without any rendered results because it'll let you place them in their own cards. 

Eventually, with better control over layout of cards in the UI, this will really let you flexibly design your solenoid page, and even make useful prototype apps.